### PR TITLE
New: Define prop types after component

### DIFF
--- a/src/components/App/Hero/Hero.tsx
+++ b/src/components/App/Hero/Hero.tsx
@@ -4,11 +4,6 @@ import { Block, Link, Text } from 'componentry'
 import { heroAreaCx } from '@/components/App/layout'
 import Github from '@/media/github.svg'
 
-type HeroProps = {
-  /** Application title */
-  title: string
-}
-
 // The container element will expand to match the height of the content in main,
 // then the inner .background element uses position sticky to stay in view when
 // app is scrolled
@@ -44,4 +39,9 @@ export function Hero({ title }: HeroProps): JSX.Element {
       </div>
     </Block>
   )
+}
+
+type HeroProps = {
+  /** Application title */
+  title: string
 }

--- a/src/components/ReactScreen/ReactContents.mdx
+++ b/src/components/ReactScreen/ReactContents.mdx
@@ -9,14 +9,14 @@
 ### Component template
 
 ```tsx
-type ExampleProps {
-  /** Indicator of how rad this component is */
-  status: 'pretty' | 'hecka'
-}
-
 export function Example({ status }: ExampleProps): JSX.Element {
   return {
     <div>This example component is {status} rad</div>
   }
+}
+
+type ExampleProps {
+  /** Indicator of how rad this component is */
+  status: 'pretty' | 'hecka'
 }
 ```

--- a/src/components/universal/CodeBlock/CodeBlock.tsx
+++ b/src/components/universal/CodeBlock/CodeBlock.tsx
@@ -4,11 +4,6 @@ import Highlight, { type Language, defaultProps } from 'prism-react-renderer'
 
 import { radicalTheme } from './radical-prism-theme'
 
-type CodeBlockProps = {
-  children: string
-  className?: string
-}
-
 // https://mdxjs.com/guides/syntax-highlighting#build-a-codeblock-component
 export function CodeBlock({
   children,
@@ -32,4 +27,9 @@ export function CodeBlock({
       )}
     </Highlight>
   )
+}
+
+type CodeBlockProps = {
+  children: string
+  className?: string
 }

--- a/src/components/universal/Link/Link.tsx
+++ b/src/components/universal/Link/Link.tsx
@@ -3,17 +3,6 @@ import { updatePathname } from 'dux-routing'
 import { ReactNode } from 'react'
 import { useDispatch } from 'react-redux'
 
-type LinkProps = {
-  children: ReactNode
-  /** Route path to link to */
-  to: string
-  /** Search params to append to route path */
-  searchParams?: Record<string, string>
-
-  // TODO: remove with Componentry types
-  mr?: string
-}
-
 export function Link({ children, to, searchParams, ...rest }: LinkProps): JSX.Element {
   const dispatch = useDispatch()
 
@@ -32,4 +21,15 @@ export function Link({ children, to, searchParams, ...rest }: LinkProps): JSX.El
       {children}
     </ComponentryLink>
   )
+}
+
+type LinkProps = {
+  children: ReactNode
+  /** Route path to link to */
+  to: string
+  /** Search params to append to route path */
+  searchParams?: Record<string, string>
+
+  // TODO: remove with Componentry types
+  mr?: string
 }


### PR DESCRIPTION
<!-- ❕📝 PR guidelines are available in the  CONTRIBUTING guide -->

## Sumary

_Improve component definition flow_

### Notes

Types can be defined after use, and that allows a nice component flow where the prop types are defined after the component code, mirroring normal prop types definition.

<!-- Thank you for contributing, you are AWESOME 🥳 -->
